### PR TITLE
chore: introduce user identity type

### DIFF
--- a/src/Domain/types.ts
+++ b/src/Domain/types.ts
@@ -1,0 +1,5 @@
+export type UserIdentity ={
+    api_key: string;
+    ip: string;
+    tenant: string;
+}


### PR DESCRIPTION
Here I introduced the user Identity type which holds the `APIkey`, `IP` and the `tenant` which identify the user in the rate limiting service to help the service make decision  whether allow the request or not. 

Closes #8 