### PR TITLE
chore: introduce certificate type

### DIFF
--- a/src/Domain/types.ts
+++ b/src/Domain/types.ts
@@ -10,6 +10,11 @@ export type Policy = {
     tenant: Rate;
 };
 
+export type Certificate = {
+    allowed: boolean;
+    retryAfter: number;
+};
+
 type Rate = {
     amount: number;
     per: number;


### PR DESCRIPTION
This type will be used as a return type from rate-limiter use case. 

closes #10 