### PR TITLE
chore: migrate project to TS runtime workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx watch src/index.ts",
-    "start": "node dist/index.js",
+    "start": "tsx src/index.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/src/Domain/TokenBucket.ts
+++ b/src/Domain/TokenBucket.ts
@@ -1,4 +1,4 @@
-import {BucketState, Decision, Rate} from "./types.js";
+import {BucketState, Decision, Rate} from "./types.ts";
 
 export function limit(
     currentBucketState: BucketState,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
     "lib": ["ES2022"],
     "rootDir": "src",
     "outDir": "dist",
@@ -11,7 +11,9 @@
     "exactOptionalPropertyTypes": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
### Motivation
- Simplify development/startup by running TypeScript sources directly with `tsx` instead of requiring a build step. 
- Allow importing `.ts` modules with explicit extensions and adapt module resolution to match the runtime used by `tsx`. 
- Fix a runtime import path in `TokenBucket` to reference the actual `.ts` types file.

### Description
- Changed the `start` script in `package.json` to `tsx src/index.ts` so the app can run TypeScript directly. 
- Updated `TokenBucket.ts` import from `./types.js` to `./types.ts` to match explicit TypeScript extension imports. 
- Modified `tsconfig.json` to set `module` to `ESNext`, `moduleResolution` to `Bundler`, added `allowImportingTsExtensions: true`, and enabled `noEmit` to support the new workflow. 
- Kept `devDependencies` including `tsx` and `typescript` and left the `typecheck` script as `tsc --noEmit`.

### Testing
- Ran the TypeScript type check with `npm run typecheck` (which invokes `tsc --noEmit`) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5193385c8326a2e0ab34c726e19a)