### PR TITLE
Implement rate limit key factory

### DIFF
--- a/src/Domain/Service/RateLimitKey.test.ts
+++ b/src/Domain/Service/RateLimitKey.test.ts
@@ -4,22 +4,22 @@ import {rateLimitKey} from "./RateLimitKey.ts";
 describe("key builder", () => {
     const cases = [
         {
-            keyOwner: "fake-user-id",
+            identity: "fake-user-id",
             key : "user"
         },
         {
-            keyOwner: "fake-ip",
+            identity: "fake-ip",
             key : "ip"
         },
         {
-            keyOwner: "fake-tenant-id",
+            identity: "fake-tenant-id",
             key : "tenant"
         }
     ] as const;
-    test.each(cases)("builds token key for $key", ({ keyOwner, key}) => {
+    test.each(cases)("builds token key for $key", ({ identity, key}) => {
 
-        const actual  = rateLimitKey(key).ownedBy(keyOwner);
+        const actual  = rateLimitKey(key).ownedBy(identity);
 
-        expect(actual).toEqual(`ratelimit:${key}:${keyOwner}:tokens`);
+        expect(actual).toEqual(`ratelimit:${key}:${identity}:tokens`);
     });
 });

--- a/src/Domain/Service/RateLimitKey.ts
+++ b/src/Domain/Service/RateLimitKey.ts
@@ -5,8 +5,8 @@ const SUFFIX = `tokens`;
 
 export function rateLimitKey(key: KeyType) : KeyBuilder{
     return {
-        ownedBy(keyOwner: string){
-            return `${PREFIX}:${key}:${keyOwner}:${SUFFIX}`;
+        ownedBy(identity: string){
+            return `${PREFIX}:${key}:${identity}:${SUFFIX}`;
         }
     }
 }

--- a/src/Domain/Service/RateLimitKeyFactory.test.ts
+++ b/src/Domain/Service/RateLimitKeyFactory.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, test} from "vitest";
-import {UserIdentity} from "../types.ts";
+import {RateLimitKeys, UserIdentity} from "../types.ts";
 import {rateLimitKeyFactory} from "./RateLimitKeyFactory.ts";
 describe("rate limit key factory", () =>  {
     test("it must have api key at least", () => {
@@ -7,11 +7,17 @@ describe("rate limit key factory", () =>  {
             apiKey: "fake-api-key"
         }
 
-        const actualkeys = rateLimitKeyFactory(userIdentity);
+        const actualKeys: RateLimitKeys = rateLimitKeyFactory(userIdentity);
 
-        expect(actualkeys).toEqual({
+        expect(actualKeys).toEqual({
             apikey: `ratelimit:user:${userIdentity.apiKey}:tokens`
         });
+    });
+
+    test("it throws an exception when api key is missing", () => {
+        const userIdentity = {} as UserIdentity;
+
+        expect(() => rateLimitKeyFactory(userIdentity)).toThrow("apikey is required to generate the keys");
     });
 
     test.each([
@@ -48,7 +54,7 @@ describe("rate limit key factory", () =>  {
             },
         },
     ])("it creates only keys for provided optional user identity fields", ({userIdentity, expectedKeys}) => {
-        const actualKeys = rateLimitKeyFactory(userIdentity);
+        const actualKeys: RateLimitKeys = rateLimitKeyFactory(userIdentity);
 
         expect(actualKeys).toEqual(expectedKeys);
     });

--- a/src/Domain/Service/RateLimitKeyFactory.test.ts
+++ b/src/Domain/Service/RateLimitKeyFactory.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, test} from "vitest";
+import {UserIdentity} from "../types.ts";
+import {rateLimitKeyFactory} from "./RateLimitKeyFactory.ts";
+describe("rate limit key factory", () =>  {
+    test("it create keys bases on givin user identity", () => {
+        const userIdentity: UserIdentity = {
+            apiKey: "fake-api-key",
+            ip: "fake-ip",
+            tenant: 'fake-tenant'
+        }
+
+        const actualkeys = rateLimitKeyFactory(userIdentity);
+
+        expect(actualkeys).toEqual({
+            apikey: `ratelimit:user:${userIdentity.apiKey}:tokens`,
+            ip: `ratelimit:ip:${userIdentity.ip}:tokens`,
+            tenant: `ratelimit:tenant:${userIdentity.tenant}:tokens`,
+        });
+    });
+});

--- a/src/Domain/Service/RateLimitKeyFactory.test.ts
+++ b/src/Domain/Service/RateLimitKeyFactory.test.ts
@@ -2,19 +2,54 @@ import {describe, expect, test} from "vitest";
 import {UserIdentity} from "../types.ts";
 import {rateLimitKeyFactory} from "./RateLimitKeyFactory.ts";
 describe("rate limit key factory", () =>  {
-    test("it create keys bases on givin user identity", () => {
+    test("it must have api key at least", () => {
         const userIdentity: UserIdentity = {
-            apiKey: "fake-api-key",
-            ip: "fake-ip",
-            tenant: 'fake-tenant'
+            apiKey: "fake-api-key"
         }
 
         const actualkeys = rateLimitKeyFactory(userIdentity);
 
         expect(actualkeys).toEqual({
-            apikey: `ratelimit:user:${userIdentity.apiKey}:tokens`,
-            ip: `ratelimit:ip:${userIdentity.ip}:tokens`,
-            tenant: `ratelimit:tenant:${userIdentity.tenant}:tokens`,
+            apikey: `ratelimit:user:${userIdentity.apiKey}:tokens`
         });
+    });
+
+    test.each([
+        {
+            userIdentity: {
+                apiKey: "fake-api-key",
+                ip: "fake-ip",
+            },
+            expectedKeys: {
+                apikey: "ratelimit:user:fake-api-key:tokens",
+                ip: "ratelimit:ip:fake-ip:tokens",
+            },
+        },
+        {
+            userIdentity: {
+                apiKey: "fake-api-key",
+                tenant: "fake-tenant",
+            },
+            expectedKeys: {
+                apikey: "ratelimit:user:fake-api-key:tokens",
+                tenant: "ratelimit:tenant:fake-tenant:tokens",
+            },
+        },
+        {
+            userIdentity: {
+                apiKey: "fake-api-key",
+                ip: "fake-ip",
+                tenant: "fake-tenant",
+            },
+            expectedKeys: {
+                apikey: "ratelimit:user:fake-api-key:tokens",
+                ip: "ratelimit:ip:fake-ip:tokens",
+                tenant: "ratelimit:tenant:fake-tenant:tokens",
+            },
+        },
+    ])("it creates only keys for provided optional user identity fields", ({userIdentity, expectedKeys}) => {
+        const actualKeys = rateLimitKeyFactory(userIdentity);
+
+        expect(actualKeys).toEqual(expectedKeys);
     });
 });

--- a/src/Domain/Service/RateLimitKeyFactory.ts
+++ b/src/Domain/Service/RateLimitKeyFactory.ts
@@ -3,12 +3,24 @@ import {rateLimitKey} from "./RateLimitKey.ts";
 
 export function rateLimitKeyFactory(userIdentity: UserIdentity): {
     apikey: string;
-    ip: string;
-    tenant: string;
+    ip?: string;
+    tenant?: string;
 } {
-    return {
+    const keys: {
+        apikey: string;
+        ip?: string;
+        tenant?: string;
+    } = {
         apikey: rateLimitKey("user").ownedBy(userIdentity.apiKey),
-        ip: rateLimitKey("ip").ownedBy(userIdentity.ip),
-        tenant: rateLimitKey("tenant").ownedBy(userIdentity.tenant),
     };
+
+    if (userIdentity.ip !== undefined) {
+        keys.ip = rateLimitKey("ip").ownedBy(userIdentity.ip);
+    }
+
+    if (userIdentity.tenant !== undefined) {
+        keys.tenant = rateLimitKey("tenant").ownedBy(userIdentity.tenant);
+    }
+
+    return keys;
 }

--- a/src/Domain/Service/RateLimitKeyFactory.ts
+++ b/src/Domain/Service/RateLimitKeyFactory.ts
@@ -1,0 +1,5 @@
+import {UserIdentity} from "../types.ts";
+
+export function rateLimitKeyFactory(userIdentity: UserIdentity): {} {
+
+}

--- a/src/Domain/Service/RateLimitKeyFactory.ts
+++ b/src/Domain/Service/RateLimitKeyFactory.ts
@@ -1,16 +1,8 @@
-import {UserIdentity} from "../types.ts";
+import {RateLimitKeys, UserIdentity} from "../types.ts";
 import {rateLimitKey} from "./RateLimitKey.ts";
 
-export function rateLimitKeyFactory(userIdentity: UserIdentity): {
-    apikey: string;
-    ip?: string;
-    tenant?: string;
-} {
-    const keys: {
-        apikey: string;
-        ip?: string;
-        tenant?: string;
-    } = {
+export function rateLimitKeyFactory(userIdentity: UserIdentity): RateLimitKeys {
+    const keys: RateLimitKeys = {
         apikey: rateLimitKey("user").ownedBy(userIdentity.apiKey),
     };
 

--- a/src/Domain/Service/RateLimitKeyFactory.ts
+++ b/src/Domain/Service/RateLimitKeyFactory.ts
@@ -1,5 +1,14 @@
 import {UserIdentity} from "../types.ts";
+import {rateLimitKey} from "./RateLimitKey.ts";
 
-export function rateLimitKeyFactory(userIdentity: UserIdentity): {} {
-
+export function rateLimitKeyFactory(userIdentity: UserIdentity): {
+    apikey: string;
+    ip: string;
+    tenant: string;
+} {
+    return {
+        apikey: rateLimitKey("user").ownedBy(userIdentity.apiKey),
+        ip: rateLimitKey("ip").ownedBy(userIdentity.ip),
+        tenant: rateLimitKey("tenant").ownedBy(userIdentity.tenant),
+    };
 }

--- a/src/Domain/Service/RateLimitKeyFactory.ts
+++ b/src/Domain/Service/RateLimitKeyFactory.ts
@@ -2,6 +2,10 @@ import {RateLimitKeys, UserIdentity} from "../types.ts";
 import {rateLimitKey} from "./RateLimitKey.ts";
 
 export function rateLimitKeyFactory(userIdentity: UserIdentity): RateLimitKeys {
+    if (!userIdentity.apiKey) {
+        throw new Error("apikey is required to generate the keys");
+    }
+
     const keys: RateLimitKeys = {
         apikey: rateLimitKey("user").ownedBy(userIdentity.apiKey),
     };

--- a/src/Domain/types.ts
+++ b/src/Domain/types.ts
@@ -34,7 +34,7 @@ export type BucketState = {
 }
 
 export type KeyBuilder = {
-    ownedBy(keyOwner: string): string;
+    ownedBy(identity: string): string;
 }
 
 export type KeyType = "user" | "ip" | "tenant";

--- a/src/Domain/types.ts
+++ b/src/Domain/types.ts
@@ -4,6 +4,12 @@ export type UserIdentity = {
     tenant?: string;
 };
 
+export type RateLimitKeys = {
+    apikey: string;
+    ip?: string;
+    tenant?: string;
+};
+
 export type Policy = {
     apiKey: Rate;
     ip?: Rate;

--- a/src/Domain/types.ts
+++ b/src/Domain/types.ts
@@ -1,13 +1,13 @@
 export type UserIdentity = {
     apiKey: string;
-    ip: string;
-    tenant: string;
+    ip?: string;
+    tenant?: string;
 };
 
 export type Policy = {
     apiKey: Rate;
-    ip: Rate;
-    tenant: Rate;
+    ip?: Rate;
+    tenant?: Rate;
 };
 
 export type Certificate = {


### PR DESCRIPTION
## Summary
- Implement `rateLimitKeyFactory` using the existing `rateLimitKey` builder
- Add support for optional `ip` and `tenant` identities while always generating an API key rate-limit key
- Add a named `RateLimitKeys` type for the factory result
- Throw an explicit error when `apiKey` is missing

## Tests
- `npx vitest run src/Domain/Service/RateLimitKeyFactory.test.ts`
- `npm run typecheck`
- `npx vitest run`