### PR TITLE
Add singleton Redis client accessor

### DIFF
--- a/src/Infrastructure/Redis/Client/getClient.test.ts
+++ b/src/Infrastructure/Redis/Client/getClient.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Config } from "./config.ts";
+import { createClient } from "./createClient.ts";
+
+type RedisClient = Awaited<ReturnType<typeof createClient>>;
+
+vi.mock("./createClient.ts", () => ({
+    createClient: vi.fn(),
+}));
+
+describe("Redis client singleton", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.resetModules();
+    });
+
+    it("should create Redis client only once", async () => {
+        const config: Config = { url: "redis://localhost:6379" };
+        const client = { id: "redis-client" } as unknown as RedisClient;
+        vi.mocked(createClient).mockResolvedValue(client);
+        const { getRedisClient } = await import("./getClient.ts");
+
+        const firstClient = await getRedisClient(config);
+        const secondClient = await getRedisClient(config);
+
+        expect(firstClient).toBe(client);
+        expect(secondClient).toBe(client);
+        expect(createClient).toHaveBeenCalledOnce();
+        expect(createClient).toHaveBeenCalledWith(config);
+    });
+
+    it("should share pending Redis client creation between concurrent calls", async () => {
+        const config: Config = { url: "redis://localhost:6379" };
+        const client = { id: "redis-client" } as unknown as RedisClient;
+        vi.mocked(createClient).mockResolvedValue(client);
+        const { getRedisClient } = await import("./getClient.ts");
+
+        const [firstClient, secondClient] = await Promise.all([
+            getRedisClient(config),
+            getRedisClient(config),
+        ]);
+
+        expect(firstClient).toBe(client);
+        expect(secondClient).toBe(client);
+        expect(createClient).toHaveBeenCalledOnce();
+    });
+
+    it("should keep using the first Redis client once initialized", async () => {
+        const firstConfig: Config = { url: "redis://localhost:6379" };
+        const secondConfig: Config = { url: "redis://localhost:6380" };
+        const client = { id: "redis-client" } as unknown as RedisClient;
+        vi.mocked(createClient).mockResolvedValue(client);
+        const { getRedisClient } = await import("./getClient.ts");
+
+        await getRedisClient(firstConfig);
+        const secondClient = await getRedisClient(secondConfig);
+
+        expect(secondClient).toBe(client);
+        expect(createClient).toHaveBeenCalledOnce();
+        expect(createClient).toHaveBeenCalledWith(firstConfig);
+    });
+});

--- a/src/Infrastructure/Redis/Client/getClient.test.ts
+++ b/src/Infrastructure/Redis/Client/getClient.test.ts
@@ -4,22 +4,23 @@ import type { Config } from "./config.ts";
 import { createClient } from "./createClient.ts";
 
 type RedisClient = Awaited<ReturnType<typeof createClient>>;
+let getRedisClient: typeof import("./getClient.ts").getRedisClient;
 
 vi.mock("./createClient.ts", () => ({
     createClient: vi.fn(),
 }));
 
 describe("Redis client singleton", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
         vi.clearAllMocks();
         vi.resetModules();
+        ({ getRedisClient } = await import("./getClient.ts"));
     });
 
     it("should create Redis client only once", async () => {
         const config: Config = { url: "redis://localhost:6379" };
         const client = { id: "redis-client" } as unknown as RedisClient;
         vi.mocked(createClient).mockResolvedValue(client);
-        const { getRedisClient } = await import("./getClient.ts");
 
         const firstClient = await getRedisClient(config);
         const secondClient = await getRedisClient(config);
@@ -34,7 +35,6 @@ describe("Redis client singleton", () => {
         const config: Config = { url: "redis://localhost:6379" };
         const client = { id: "redis-client" } as unknown as RedisClient;
         vi.mocked(createClient).mockResolvedValue(client);
-        const { getRedisClient } = await import("./getClient.ts");
 
         const [firstClient, secondClient] = await Promise.all([
             getRedisClient(config),
@@ -51,7 +51,6 @@ describe("Redis client singleton", () => {
         const secondConfig: Config = { url: "redis://localhost:6380" };
         const client = { id: "redis-client" } as unknown as RedisClient;
         vi.mocked(createClient).mockResolvedValue(client);
-        const { getRedisClient } = await import("./getClient.ts");
 
         await getRedisClient(firstConfig);
         const secondClient = await getRedisClient(secondConfig);
@@ -59,5 +58,19 @@ describe("Redis client singleton", () => {
         expect(secondClient).toBe(client);
         expect(createClient).toHaveBeenCalledOnce();
         expect(createClient).toHaveBeenCalledWith(firstConfig);
+    });
+
+    it("should retry Redis client creation after a failed connection", async () => {
+        const config: Config = { url: "redis://localhost:6379" };
+        const client = { id: "redis-client" } as unknown as RedisClient;
+        vi.mocked(createClient)
+            .mockRejectedValueOnce(new Error("connection failed"))
+            .mockResolvedValueOnce(client);
+
+        await expect(getRedisClient(config)).rejects.toThrow("connection failed");
+        await expect(getRedisClient(config)).resolves.toBe(client);
+
+        expect(createClient).toHaveBeenCalledTimes(2);
+        expect(createClient).toHaveBeenCalledWith(config);
     });
 });

--- a/src/Infrastructure/Redis/Client/getClient.test.ts
+++ b/src/Infrastructure/Redis/Client/getClient.test.ts
@@ -4,7 +4,7 @@ import type { Config } from "./config.ts";
 import { createClient } from "./createClient.ts";
 
 type RedisClient = Awaited<ReturnType<typeof createClient>>;
-let getRedisClient: typeof import("./getClient.ts").getRedisClient;
+let getClient: typeof import("./getClient.ts").getClient;
 
 vi.mock("./createClient.ts", () => ({
     createClient: vi.fn(),
@@ -14,7 +14,7 @@ describe("Redis client singleton", () => {
     beforeEach(async () => {
         vi.clearAllMocks();
         vi.resetModules();
-        ({ getRedisClient } = await import("./getClient.ts"));
+        ({ getClient } = await import("./getClient.ts"));
     });
 
     it("should create Redis client only once", async () => {
@@ -22,8 +22,8 @@ describe("Redis client singleton", () => {
         const client = { id: "redis-client" } as unknown as RedisClient;
         vi.mocked(createClient).mockResolvedValue(client);
 
-        const firstClient = await getRedisClient(config);
-        const secondClient = await getRedisClient(config);
+        const firstClient = await getClient(config);
+        const secondClient = await getClient(config);
 
         expect(firstClient).toBe(client);
         expect(secondClient).toBe(client);
@@ -37,8 +37,8 @@ describe("Redis client singleton", () => {
         vi.mocked(createClient).mockResolvedValue(client);
 
         const [firstClient, secondClient] = await Promise.all([
-            getRedisClient(config),
-            getRedisClient(config),
+            getClient(config),
+            getClient(config),
         ]);
 
         expect(firstClient).toBe(client);
@@ -52,8 +52,8 @@ describe("Redis client singleton", () => {
         const client = { id: "redis-client" } as unknown as RedisClient;
         vi.mocked(createClient).mockResolvedValue(client);
 
-        await getRedisClient(firstConfig);
-        const secondClient = await getRedisClient(secondConfig);
+        await getClient(firstConfig);
+        const secondClient = await getClient(secondConfig);
 
         expect(secondClient).toBe(client);
         expect(createClient).toHaveBeenCalledOnce();
@@ -67,8 +67,8 @@ describe("Redis client singleton", () => {
             .mockRejectedValueOnce(new Error("connection failed"))
             .mockResolvedValueOnce(client);
 
-        await expect(getRedisClient(config)).rejects.toThrow("connection failed");
-        await expect(getRedisClient(config)).resolves.toBe(client);
+        await expect(getClient(config)).rejects.toThrow("connection failed");
+        await expect(getClient(config)).resolves.toBe(client);
 
         expect(createClient).toHaveBeenCalledTimes(2);
         expect(createClient).toHaveBeenCalledWith(config);

--- a/src/Infrastructure/Redis/Client/getClient.test.ts
+++ b/src/Infrastructure/Redis/Client/getClient.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import type { Config } from "./config.ts";
 import { createClient } from "./createClient.ts";
 

--- a/src/Infrastructure/Redis/Client/getClient.ts
+++ b/src/Infrastructure/Redis/Client/getClient.ts
@@ -5,7 +5,7 @@ export type RedisClient = Awaited<ReturnType<typeof createClient>>;
 
 let clientPromise: Promise<RedisClient> | undefined;
 
-export function getRedisClient(
+export function getClient(
     redisConfig: Config = config,
 ): Promise<RedisClient> {
     clientPromise ??= createClient(redisConfig).catch((error: unknown) => {

--- a/src/Infrastructure/Redis/Client/getClient.ts
+++ b/src/Infrastructure/Redis/Client/getClient.ts
@@ -8,7 +8,10 @@ let clientPromise: Promise<RedisClient> | undefined;
 export function getRedisClient(
     redisConfig: Config = config,
 ): Promise<RedisClient> {
-    clientPromise ??= createClient(redisConfig);
+    clientPromise ??= createClient(redisConfig).catch((error: unknown) => {
+        clientPromise = undefined;
+        throw error;
+    });
 
     return clientPromise;
 }

--- a/src/Infrastructure/Redis/Client/getClient.ts
+++ b/src/Infrastructure/Redis/Client/getClient.ts
@@ -1,0 +1,14 @@
+import { config, type Config } from "./config.ts";
+import { createClient } from "./createClient.ts";
+
+export type RedisClient = Awaited<ReturnType<typeof createClient>>;
+
+let clientPromise: Promise<RedisClient> | undefined;
+
+export function getRedisClient(
+    redisConfig: Config = config,
+): Promise<RedisClient> {
+    clientPromise ??= createClient(redisConfig);
+
+    return clientPromise;
+}


### PR DESCRIPTION
## Summary
- Add a Redis client accessor that follows a singleton pattern by caching the in-flight client promise.
- Cover the behavior with focused tests for single creation, concurrent calls, first-config wins, and retry after an initial connection failure.
- Reset the cached promise when initial Redis connection creation fails so the next call can retry.

## Design Notes
- `getClient` uses a singleton promise so concurrent startup calls share the same Redis connection attempt instead of creating multiple Redis clients.
- `getClient` is intentionally not marked `async` because it does not need to await internally. It returns the exact cached promise from `createClient`, which preserves promise identity for concurrent callers. If it were `async`, each call would wrap the cached promise in a new promise even though the underlying Redis client would still be shared.
For singleton code, returning the exact same promise is useful because concurrent callers share the same in-flight connection:
```
const a = getClient();
const b = getClient();
```
a === b; // true with non-async function
If we mark it async, this becomes:
```
const a = getClient();
const b = getClient();
```
a === b; // false
- `createClient` remains `async` because it performs the actual asynchronous connection work with `await client.connect()`.
