### PR TITLE
Introduce Redis bucket repository

### DIFF
--- a/src/Domain/Repository/BucketRepository.ts
+++ b/src/Domain/Repository/BucketRepository.ts
@@ -1,0 +1,6 @@
+import type { BucketState } from "../types.ts";
+
+export type BucketRepository = {
+    get(key: string): Promise<BucketState | null>;
+    set(key: string, bucketState: BucketState): Promise<void>;
+};

--- a/src/Domain/TokenBucket.ts
+++ b/src/Domain/TokenBucket.ts
@@ -13,13 +13,13 @@ export function limit(
     const allowed: boolean = remainingTokens >= 0;
 
     if (allowed) {
-        const truncedRemainingTokens = Math.trunc(remainingTokens*100)/100;
+        const truncatedRemainingTokens = Math.trunc(remainingTokens*100)/100;
         return {
             allowed,
             retryAfter: 0,
-            remainingTokens: Math.floor(truncedRemainingTokens),
+            remainingTokens: Math.floor(truncatedRemainingTokens),
             bucketState: {
-                tokensCount: truncedRemainingTokens,
+                tokensCount: truncatedRemainingTokens,
                 lastUpdatedAtInMs: requestedAtInMs,
             }
         };

--- a/src/Infrastructure/Redis/Repository/RedisBucketRepository.test.ts
+++ b/src/Infrastructure/Redis/Repository/RedisBucketRepository.test.ts
@@ -17,4 +17,23 @@ describe("Redis bucket repository", () => {
         expect(bucketState).toBeNull();
         expect(redisClient.get).toHaveBeenCalledWith(key);
     });
+
+    test("returns bucket state when bucket exists", async () => {
+        const key = "bucket:user:123";
+        const expectedBucketState = {
+            tokensCount: 3,
+            lastUpdatedAtInMs: 1_000,
+        };
+        const redisClient = {
+            get: vi.fn().mockResolvedValue(JSON.stringify(expectedBucketState)),
+            set: vi.fn(),
+        };
+        const repository = new RedisBucketRepository(redisClient as unknown as RedisClient);
+
+        const bucketState = await repository.get(key);
+
+        expect(bucketState?.tokensCount).toEqual(expectedBucketState.tokensCount);
+        expect(bucketState?.lastUpdatedAtInMs).toEqual(expectedBucketState.lastUpdatedAtInMs);
+        expect(redisClient.get).toHaveBeenCalledWith(key);
+    });
 });

--- a/src/Infrastructure/Redis/Repository/RedisBucketRepository.test.ts
+++ b/src/Infrastructure/Redis/Repository/RedisBucketRepository.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { RedisClient } from "../Client/getClient.ts";
+import { RedisBucketRepository } from "./RedisBucketRepository.ts";
+
+describe("Redis bucket repository", () => {
+    test("returns null when bucket does not exist", async () => {
+        const key = "bucket:user:123";
+        const redisClient = {
+            get: vi.fn().mockResolvedValue(null),
+            set: vi.fn(),
+        };
+        const repository = new RedisBucketRepository(redisClient as unknown as RedisClient);
+
+        const bucketState = await repository.get(key);
+
+        expect(bucketState).toBeNull();
+        expect(redisClient.get).toHaveBeenCalledWith(key);
+    });
+});

--- a/src/Infrastructure/Redis/Repository/RedisBucketRepository.test.ts
+++ b/src/Infrastructure/Redis/Repository/RedisBucketRepository.test.ts
@@ -36,4 +36,21 @@ describe("Redis bucket repository", () => {
         expect(bucketState?.lastUpdatedAtInMs).toEqual(expectedBucketState.lastUpdatedAtInMs);
         expect(redisClient.get).toHaveBeenCalledWith(key);
     });
+
+    test("sets bucket state as json", async () => {
+        const key = "bucket:user:123";
+        const bucketState = {
+            tokensCount: 2,
+            lastUpdatedAtInMs: 2_000,
+        };
+        const redisClient = {
+            get: vi.fn(),
+            set: vi.fn(),
+        };
+        const repository = new RedisBucketRepository(redisClient as unknown as RedisClient);
+
+        await repository.set(key, bucketState);
+
+        expect(redisClient.set).toHaveBeenCalledWith(key, JSON.stringify(bucketState));
+    });
 });

--- a/src/Infrastructure/Redis/Repository/RedisBucketRepository.ts
+++ b/src/Infrastructure/Redis/Repository/RedisBucketRepository.ts
@@ -1,0 +1,19 @@
+import type { BucketRepository } from "../../../Domain/Repository/BucketRepository.ts";
+import type { BucketState } from "../../../Domain/types.ts";
+import type { RedisClient } from "../Client/getClient.ts";
+
+export class RedisBucketRepository implements BucketRepository {
+    constructor(private readonly redisClient: RedisClient) {}
+
+    async get(key: string): Promise<BucketState | null> {
+        const bucketState = await this.redisClient.get(key);
+
+        if (bucketState === null) {
+            return null;
+        }
+
+        return null;
+    }
+
+    async set(_key: string, _bucketState: BucketState): Promise<void> {}
+}

--- a/src/Infrastructure/Redis/Repository/RedisBucketRepository.ts
+++ b/src/Infrastructure/Redis/Repository/RedisBucketRepository.ts
@@ -15,5 +15,7 @@ export class RedisBucketRepository implements BucketRepository {
         return JSON.parse(bucketState) as BucketState;
     }
 
-    async set(_key: string, _bucketState: BucketState): Promise<void> {}
+    async set(key: string, bucketState: BucketState): Promise<void> {
+        await this.redisClient.set(key, JSON.stringify(bucketState));
+    }
 }

--- a/src/Infrastructure/Redis/Repository/RedisBucketRepository.ts
+++ b/src/Infrastructure/Redis/Repository/RedisBucketRepository.ts
@@ -12,7 +12,7 @@ export class RedisBucketRepository implements BucketRepository {
             return null;
         }
 
-        return null;
+        return JSON.parse(bucketState) as BucketState;
     }
 
     async set(_key: string, _bucketState: BucketState): Promise<void> {}


### PR DESCRIPTION
## Summary

This PR introduces the bucket repository boundary and a Redis-backed implementation for storing token bucket state.

## Changes

- Added `BucketRepository` contract under the Domain layer.
- Added `RedisBucketRepository` under the Infrastructure Redis layer.
- Implemented bucket lookup from Redis:
  - returns `null` when the bucket key does not exist
  - parses stored JSON into `BucketState` when the key exists
- Implemented bucket persistence to Redis as JSON.
- Added focused unit tests following AAA style and plain-English test names.

## Architecture Notes

- The domain owns the repository interface so the core rate limiting logic does not depend on Redis.
- Redis-specific concerns stay in the infrastructure layer.
- Redis storage is intentionally simple JSON for now.
- TTL is intentionally not included yet; it can be added later with policy-aware behavior.

## TDD / Commit Slices

- `Add bucket repository contract`
- `Add Redis bucket lookup`
- `Read bucket state from Redis`
- `Write bucket state to Redis`

Closes #28 