### PR TITLE
Implement decision evaulator

### DIFF
--- a/src/Application/EnforceRateLimitUseCase.test.ts
+++ b/src/Application/EnforceRateLimitUseCase.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import { DecisionEvaluator } from "../Domain/Service/DecisionEvaluator.ts";
-import { LimitService } from "../Domain/Service/LimitService.ts";
+import { rateLimiterService } from "../Domain/Service/RateLimiterService.ts";
 import {
   EnforcementDecision,
   LimitDecisions,
@@ -63,7 +63,7 @@ describe("enforce rate limit use case", () => {
     );
     const limitService = {
       execute: vi.fn().mockResolvedValue(expectedDecisions),
-    } as unknown as LimitService<FakeState, FakePolicy>;
+    } as unknown as rateLimiterService<FakeState, FakePolicy>;
     const decisionEvaluator = {
       evaluate: vi.fn().mockReturnValue(expectedEnforcementDecision),
     } as unknown as DecisionEvaluator;
@@ -82,7 +82,7 @@ describe("enforce rate limit use case", () => {
     expect(actualDecision).toEqual(expectedEnforcementDecision);
     expect(limitService.execute).toHaveBeenCalledWith(
       {
-        apikey: "example-user-for-fake-api-key",
+        apiKey: "example-user-for-fake-api-key",
         ip: "example-ip-for-fake-ip",
         tenant: "example-tenant-for-fake-tenant",
       },
@@ -106,7 +106,7 @@ describe("enforce rate limit use case", () => {
     );
     const limitService = {
       execute: vi.fn(),
-    } as unknown as LimitService<FakeState, FakePolicy>;
+    } as unknown as rateLimiterService<FakeState, FakePolicy>;
     const decisionEvaluator = {
       evaluate: vi.fn(),
     } as unknown as DecisionEvaluator;
@@ -136,7 +136,7 @@ describe("enforce rate limit use case", () => {
     );
     const limitService = {
       execute: vi.fn(),
-    } as unknown as LimitService<FakeState, FakePolicy>;
+    } as unknown as rateLimiterService<FakeState, FakePolicy>;
     const decisionEvaluator = {
       evaluate: vi.fn(),
     } as unknown as DecisionEvaluator;

--- a/src/Application/EnforceRateLimitUseCase.test.ts
+++ b/src/Application/EnforceRateLimitUseCase.test.ts
@@ -4,10 +4,10 @@ import { rateLimiterService } from "../Domain/Service/RateLimiterService.ts";
 import {
   EnforcementDecision,
   LimitDecisions,
-  LimitPolicies,
+  Policies,
 } from "../Domain/types.ts";
 import { EnforceRateLimitUseCase } from "./EnforceRateLimitUseCase.ts";
-import { Identifier, IdentifierScope, UserIdentity } from "./types.ts";
+import { Identifier, IdentifierScope, Identities } from "./types.ts";
 
 type FakeState = {
   key: string;
@@ -19,12 +19,12 @@ type FakePolicy = {
 
 describe("enforce rate limit use case", () => {
   test("should return the enforcement decision for the requested user identities", async () => {
-    const userIdentity: UserIdentity = {
+    const userIdentity: Identities = {
       apiKey: "fake-api-key",
       ip: "fake-ip",
       tenant: "fake-tenant",
     };
-    const policies: LimitPolicies<FakePolicy> = {
+    const policies: Policies<FakePolicy> = {
       apiKey: { key: "api-key-policy" },
       ip: { key: "ip-policy" },
       tenant: { key: "tenant-policy" },
@@ -93,8 +93,8 @@ describe("enforce rate limit use case", () => {
   });
 
   test("should reject requests when the api key identity is missing", async () => {
-    const userIdentity = {} as UserIdentity;
-    const policies: LimitPolicies<FakePolicy> = {
+    const userIdentity = {} as Identities;
+    const policies: Policies<FakePolicy> = {
       apiKey: { key: "api-key-policy" },
     };
     const identifierBuilder = vi.fn(
@@ -123,10 +123,10 @@ describe("enforce rate limit use case", () => {
   });
 
   test("should reject requests when the api key policy is missing", async () => {
-    const userIdentity: UserIdentity = {
+    const userIdentity: Identities = {
       apiKey: "fake-api-key",
     };
-    const policies = {} as LimitPolicies<FakePolicy>;
+    const policies = {} as Policies<FakePolicy>;
     const identifierBuilder = vi.fn(
       (scope: IdentifierScope): Identifier => ({
         ownedBy: vi.fn(

--- a/src/Application/EnforceRateLimitUseCase.test.ts
+++ b/src/Application/EnforceRateLimitUseCase.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test, vi } from "vitest";
+import { DecisionEvaluator } from "../Domain/Service/DecisionEvaluator.ts";
 import { LimitService } from "../Domain/Service/LimitService.ts";
-import { LimitDecisions, LimitPolicies } from "../Domain/types.ts";
+import {
+  EnforcementDecision,
+  LimitDecisions,
+  LimitPolicies,
+} from "../Domain/types.ts";
 import { EnforceRateLimitUseCase } from "./EnforceRateLimitUseCase.ts";
 import { Identifier, IdentifierScope, UserIdentity } from "./types.ts";
 
@@ -13,7 +18,7 @@ type FakePolicy = {
 };
 
 describe("enforce rate limit use case", () => {
-  test("should return decisions for the requested user identities", async () => {
+  test("should return the enforcement decision for the requested user identities", async () => {
     const userIdentity: UserIdentity = {
       apiKey: "fake-api-key",
       ip: "fake-ip",
@@ -45,6 +50,10 @@ describe("enforce rate limit use case", () => {
         nextState: { key: "tenant-state" },
       },
     };
+    const expectedEnforcementDecision: EnforcementDecision = {
+      allowed: false,
+      retryAfter: 500,
+    };
     const identifierBuilder = vi.fn(
       (scope: IdentifierScope): Identifier => ({
         ownedBy: vi.fn(
@@ -55,18 +64,22 @@ describe("enforce rate limit use case", () => {
     const limitService = {
       execute: vi.fn().mockResolvedValue(expectedDecisions),
     } as unknown as LimitService<FakeState, FakePolicy>;
+    const decisionEvaluator = {
+      evaluate: vi.fn().mockReturnValue(expectedEnforcementDecision),
+    } as unknown as DecisionEvaluator;
     const useCase = new EnforceRateLimitUseCase(
       identifierBuilder,
       limitService,
+      decisionEvaluator,
     );
 
-    const actualDecisions = await useCase.enforce(
+    const actualDecision = await useCase.enforce(
       userIdentity,
       policies,
       requestedAt,
     );
 
-    expect(actualDecisions).toEqual(expectedDecisions);
+    expect(actualDecision).toEqual(expectedEnforcementDecision);
     expect(limitService.execute).toHaveBeenCalledWith(
       {
         apikey: "example-user-for-fake-api-key",
@@ -76,6 +89,7 @@ describe("enforce rate limit use case", () => {
       policies,
       requestedAt,
     );
+    expect(decisionEvaluator.evaluate).toHaveBeenCalledWith(expectedDecisions);
   });
 
   test("should reject requests when the api key identity is missing", async () => {
@@ -93,9 +107,13 @@ describe("enforce rate limit use case", () => {
     const limitService = {
       execute: vi.fn(),
     } as unknown as LimitService<FakeState, FakePolicy>;
+    const decisionEvaluator = {
+      evaluate: vi.fn(),
+    } as unknown as DecisionEvaluator;
     const useCase = new EnforceRateLimitUseCase(
       identifierBuilder,
       limitService,
+      decisionEvaluator,
     );
 
     await expect(
@@ -119,9 +137,13 @@ describe("enforce rate limit use case", () => {
     const limitService = {
       execute: vi.fn(),
     } as unknown as LimitService<FakeState, FakePolicy>;
+    const decisionEvaluator = {
+      evaluate: vi.fn(),
+    } as unknown as DecisionEvaluator;
     const useCase = new EnforceRateLimitUseCase(
       identifierBuilder,
       limitService,
+      decisionEvaluator,
     );
 
     await expect(

--- a/src/Application/EnforceRateLimitUseCase.ts
+++ b/src/Application/EnforceRateLimitUseCase.ts
@@ -1,5 +1,5 @@
 import { DecisionEvaluator } from "../Domain/Service/DecisionEvaluator.ts";
-import { LimitService } from "../Domain/Service/LimitService.ts";
+import { rateLimiterService } from "../Domain/Service/RateLimiterService.ts";
 import {
   EnforcementDecision,
   LimitPolicies,
@@ -11,7 +11,7 @@ import { IdentifierBuilder, UserIdentity } from "./types.ts";
 export class EnforceRateLimitUseCase<State, Policy> {
   constructor(
     private readonly identifierBuilder: IdentifierBuilder,
-    private readonly limitService: LimitService<State, Policy>,
+    private readonly rateLimiterService: rateLimiterService<State, Policy>,
     private readonly decisionEvaluator: DecisionEvaluator,
   ) {}
 
@@ -33,7 +33,7 @@ export class EnforceRateLimitUseCase<State, Policy> {
       userIdentity,
     );
 
-    const decisions = await this.limitService.execute(
+    const decisions = await this.rateLimiterService.execute(
       stateIdentifiers,
       policies,
       requestedAt,

--- a/src/Application/EnforceRateLimitUseCase.ts
+++ b/src/Application/EnforceRateLimitUseCase.ts
@@ -1,6 +1,7 @@
+import { DecisionEvaluator } from "../Domain/Service/DecisionEvaluator.ts";
 import { LimitService } from "../Domain/Service/LimitService.ts";
 import {
-  LimitDecisions,
+  EnforcementDecision,
   LimitPolicies,
   StateIdentifiers,
 } from "../Domain/types.ts";
@@ -11,13 +12,14 @@ export class EnforceRateLimitUseCase<State, Policy> {
   constructor(
     private readonly identifierBuilder: IdentifierBuilder,
     private readonly limitService: LimitService<State, Policy>,
+    private readonly decisionEvaluator: DecisionEvaluator,
   ) {}
 
   async enforce(
     userIdentity: UserIdentity,
     policies: LimitPolicies<Policy>,
     requestedAt: number,
-  ): Promise<LimitDecisions<State>> {
+  ): Promise<EnforcementDecision> {
     if (!userIdentity.apiKey) {
       throw new Error("apikey is required to enforce rate limits");
     }
@@ -31,6 +33,12 @@ export class EnforceRateLimitUseCase<State, Policy> {
       userIdentity,
     );
 
-    return this.limitService.execute(stateIdentifiers, policies, requestedAt);
+    const decisions = await this.limitService.execute(
+      stateIdentifiers,
+      policies,
+      requestedAt,
+    );
+
+    return this.decisionEvaluator.evaluate(decisions);
   }
 }

--- a/src/Application/EnforceRateLimitUseCase.ts
+++ b/src/Application/EnforceRateLimitUseCase.ts
@@ -2,11 +2,11 @@ import { DecisionEvaluator } from "../Domain/Service/DecisionEvaluator.ts";
 import { rateLimiterService } from "../Domain/Service/RateLimiterService.ts";
 import {
   EnforcementDecision,
-  LimitPolicies,
+  Policies,
   StateIdentifiers,
 } from "../Domain/types.ts";
 import { stateIdentifierFactory } from "./StateIdentifierFactory.ts";
-import { IdentifierBuilder, UserIdentity } from "./types.ts";
+import { IdentifierBuilder, Identities } from "./types.ts";
 
 export class EnforceRateLimitUseCase<State, Policy> {
   constructor(
@@ -16,11 +16,11 @@ export class EnforceRateLimitUseCase<State, Policy> {
   ) {}
 
   async enforce(
-    userIdentity: UserIdentity,
-    policies: LimitPolicies<Policy>,
+    identities: Identities,
+    policies: Policies<Policy>,
     requestedAt: number,
   ): Promise<EnforcementDecision> {
-    if (!userIdentity.apiKey) {
+    if (!identities.apiKey) {
       throw new Error("apikey is required to enforce rate limits");
     }
 
@@ -30,7 +30,7 @@ export class EnforceRateLimitUseCase<State, Policy> {
 
     const stateIdentifiers: StateIdentifiers = stateIdentifierFactory(
       this.identifierBuilder,
-      userIdentity,
+      identities,
     );
 
     const decisions = await this.rateLimiterService.execute(

--- a/src/Application/StateIdentifierFactory.test.ts
+++ b/src/Application/StateIdentifierFactory.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "vitest";
 import { stateIdentifierFactory } from "./StateIdentifierFactory.ts";
-import { Identifier, IdentifierScope, UserIdentity } from "./types.ts";
+import { Identifier, IdentifierScope, Identities } from "./types.ts";
 import { StateIdentifiers } from "../Domain/types.ts";
 describe("state identifier factory", () => {
   test("it must have api key at least", () => {
-    const userIdentity: UserIdentity = {
+    const userIdentity: Identities = {
       apiKey: "fake-api-key",
     };
 
@@ -19,7 +19,7 @@ describe("state identifier factory", () => {
   });
 
   test("it throws an exception when api key is missing", () => {
-    const userIdentity = {} as UserIdentity;
+    const userIdentity = {} as Identities;
 
     expect(() =>
       stateIdentifierFactory(ExampleIdentifierBuilder, userIdentity),

--- a/src/Application/StateIdentifierFactory.test.ts
+++ b/src/Application/StateIdentifierFactory.test.ts
@@ -14,7 +14,7 @@ describe("state identifier factory", () => {
     );
 
     expect(actualKeys).toEqual({
-      apikey: `build-example-user-for-${userIdentity.apiKey}`,
+      apiKey: `build-example-user-for-${userIdentity.apiKey}`,
     });
   });
 
@@ -23,7 +23,7 @@ describe("state identifier factory", () => {
 
     expect(() =>
       stateIdentifierFactory(ExampleIdentifierBuilder, userIdentity),
-    ).toThrow("apikey is required to generate the identifiers");
+    ).toThrow("apiKey is required to generate the identifiers");
   });
 
   test.each([
@@ -33,7 +33,7 @@ describe("state identifier factory", () => {
         ip: "fake-ip",
       },
       expectedKeys: {
-        apikey: "build-example-user-for-fake-api-key",
+        apiKey: "build-example-user-for-fake-api-key",
         ip: "build-example-ip-for-fake-ip",
       },
     },
@@ -43,7 +43,7 @@ describe("state identifier factory", () => {
         tenant: "fake-tenant",
       },
       expectedKeys: {
-        apikey: "build-example-user-for-fake-api-key",
+        apiKey: "build-example-user-for-fake-api-key",
         tenant: "build-example-tenant-for-fake-tenant",
       },
     },
@@ -54,7 +54,7 @@ describe("state identifier factory", () => {
         tenant: "fake-tenant",
       },
       expectedKeys: {
-        apikey: "build-example-user-for-fake-api-key",
+        apiKey: "build-example-user-for-fake-api-key",
         ip: "build-example-ip-for-fake-ip",
         tenant: "build-example-tenant-for-fake-tenant",
       },

--- a/src/Application/StateIdentifierFactory.ts
+++ b/src/Application/StateIdentifierFactory.ts
@@ -6,11 +6,11 @@ export function stateIdentifierFactory(
   userIdentity: UserIdentity,
 ): StateIdentifiers {
   if (!userIdentity.apiKey) {
-    throw new Error("apikey is required to generate the identifiers");
+    throw new Error("apiKey is required to generate the identifiers");
   }
 
   const keys: StateIdentifiers = {
-    apikey: identifierBuilder("user").ownedBy(userIdentity.apiKey),
+    apiKey: identifierBuilder("user").ownedBy(userIdentity.apiKey),
   };
 
   if (userIdentity.ip !== undefined) {

--- a/src/Application/StateIdentifierFactory.ts
+++ b/src/Application/StateIdentifierFactory.ts
@@ -1,24 +1,24 @@
-import { IdentifierBuilder, UserIdentity } from "./types.ts";
+import { IdentifierBuilder, Identities } from "./types.ts";
 import { StateIdentifiers } from "../Domain/types.ts";
 
 export function stateIdentifierFactory(
   identifierBuilder: IdentifierBuilder,
-  userIdentity: UserIdentity,
+  identities: Identities,
 ): StateIdentifiers {
-  if (!userIdentity.apiKey) {
+  if (!identities.apiKey) {
     throw new Error("apiKey is required to generate the identifiers");
   }
 
   const keys: StateIdentifiers = {
-    apiKey: identifierBuilder("user").ownedBy(userIdentity.apiKey),
+    apiKey: identifierBuilder("user").ownedBy(identities.apiKey),
   };
 
-  if (userIdentity.ip !== undefined) {
-    keys.ip = identifierBuilder("ip").ownedBy(userIdentity.ip);
+  if (identities.ip !== undefined) {
+    keys.ip = identifierBuilder("ip").ownedBy(identities.ip);
   }
 
-  if (userIdentity.tenant !== undefined) {
-    keys.tenant = identifierBuilder("tenant").ownedBy(userIdentity.tenant);
+  if (identities.tenant !== undefined) {
+    keys.tenant = identifierBuilder("tenant").ownedBy(identities.tenant);
   }
 
   return keys;

--- a/src/Application/types.ts
+++ b/src/Application/types.ts
@@ -6,7 +6,7 @@ export type Identifier = {
 
 export type IdentifierBuilder = (scope: IdentifierScope) => Identifier;
 
-export type UserIdentity = {
+export type Identities = {
   apiKey: string;
   ip?: string;
   tenant?: string;

--- a/src/Domain/Service/DecisionEvaluator.test.ts
+++ b/src/Domain/Service/DecisionEvaluator.test.ts
@@ -99,4 +99,23 @@ describe("decision evaluator", () => {
       retryAfter: 500,
     });
   });
+
+  test("should ignore dimensions that were not evaluated", () => {
+    const decisions: LimitDecisions<FakeState> = {
+      apiKey: {
+        allowed: true,
+        retryAfter: 0,
+        remaining: 9,
+        nextState: { key: "api-key-state" },
+      },
+    };
+    const evaluator = new DecisionEvaluator();
+
+    const actualDecision = evaluator.evaluate(decisions);
+
+    expect(actualDecision).toEqual({
+      allowed: true,
+      retryAfter: 0,
+    });
+  });
 });

--- a/src/Domain/Service/DecisionEvaluator.test.ts
+++ b/src/Domain/Service/DecisionEvaluator.test.ts
@@ -68,4 +68,35 @@ describe("decision evaluator", () => {
       retryAfter: 500,
     });
   });
+
+  test("should return the maximum retry after from rejected dimensions", () => {
+    const decisions: LimitDecisions<FakeState> = {
+      apiKey: {
+        allowed: false,
+        retryAfter: 200,
+        remaining: 0,
+        nextState: { key: "api-key-state" },
+      },
+      ip: {
+        allowed: false,
+        retryAfter: 500,
+        remaining: 0,
+        nextState: { key: "ip-state" },
+      },
+      tenant: {
+        allowed: true,
+        retryAfter: 0,
+        remaining: 19,
+        nextState: { key: "tenant-state" },
+      },
+    };
+    const evaluator = new DecisionEvaluator();
+
+    const actualDecision = evaluator.evaluate(decisions);
+
+    expect(actualDecision).toEqual({
+      allowed: false,
+      retryAfter: 500,
+    });
+  });
 });

--- a/src/Domain/Service/DecisionEvaluator.test.ts
+++ b/src/Domain/Service/DecisionEvaluator.test.ts
@@ -37,4 +37,35 @@ describe("decision evaluator", () => {
       retryAfter: 0,
     });
   });
+
+  test("should return a rejected enforcement decision when any evaluated dimension is rejected", () => {
+    const decisions: LimitDecisions<FakeState> = {
+      apiKey: {
+        allowed: true,
+        retryAfter: 0,
+        remaining: 9,
+        nextState: { key: "api-key-state" },
+      },
+      ip: {
+        allowed: false,
+        retryAfter: 500,
+        remaining: 0,
+        nextState: { key: "ip-state" },
+      },
+      tenant: {
+        allowed: true,
+        retryAfter: 0,
+        remaining: 19,
+        nextState: { key: "tenant-state" },
+      },
+    };
+    const evaluator = new DecisionEvaluator();
+
+    const actualDecision = evaluator.evaluate(decisions);
+
+    expect(actualDecision).toEqual({
+      allowed: false,
+      retryAfter: 500,
+    });
+  });
 });

--- a/src/Domain/Service/DecisionEvaluator.test.ts
+++ b/src/Domain/Service/DecisionEvaluator.test.ts
@@ -2,32 +2,13 @@ import { describe, expect, test } from "vitest";
 import { LimitDecisions } from "../types.ts";
 import { DecisionEvaluator } from "./DecisionEvaluator.ts";
 
-type FakeState = {
-  key: string;
-};
-
 describe("decision evaluator", () => {
-  test("should return an allowed enforcement decision when all evaluated dimensions are allowed", () => {
-    const decisions: LimitDecisions<FakeState> = {
-      apiKey: {
-        allowed: true,
-        retryAfter: 0,
-        remaining: 9,
-        nextState: { key: "api-key-state" },
-      },
-      ip: {
-        allowed: true,
-        retryAfter: 0,
-        remaining: 4,
-        nextState: { key: "ip-state" },
-      },
-      tenant: {
-        allowed: true,
-        retryAfter: 0,
-        remaining: 19,
-        nextState: { key: "tenant-state" },
-      },
-    };
+  test("should return an allowed enforcement decision when all dimensions are allowed", () => {
+    const decisions = {
+      apiKey: { allowed: true, retryAfter: 0 },
+      ip: { allowed: true, retryAfter: 0 },
+      tenant: { allowed: true, retryAfter: 0 },
+    } as unknown as LimitDecisions<never>;
     const evaluator = new DecisionEvaluator();
 
     const actualDecision = evaluator.evaluate(decisions);
@@ -38,27 +19,12 @@ describe("decision evaluator", () => {
     });
   });
 
-  test("should return a rejected enforcement decision when any evaluated dimension is rejected", () => {
-    const decisions: LimitDecisions<FakeState> = {
-      apiKey: {
-        allowed: true,
-        retryAfter: 0,
-        remaining: 9,
-        nextState: { key: "api-key-state" },
-      },
-      ip: {
-        allowed: false,
-        retryAfter: 500,
-        remaining: 0,
-        nextState: { key: "ip-state" },
-      },
-      tenant: {
-        allowed: true,
-        retryAfter: 0,
-        remaining: 19,
-        nextState: { key: "tenant-state" },
-      },
-    };
+  test("should return a rejected enforcement decision when any dimension is rejected", () => {
+    const decisions = {
+      apiKey: { allowed: true, retryAfter: 0 },
+      ip: { allowed: false, retryAfter: 500 },
+      tenant: { allowed: true, retryAfter: 0 },
+    } as unknown as LimitDecisions<never>;
     const evaluator = new DecisionEvaluator();
 
     const actualDecision = evaluator.evaluate(decisions);
@@ -70,26 +36,11 @@ describe("decision evaluator", () => {
   });
 
   test("should return the maximum retry after from rejected dimensions", () => {
-    const decisions: LimitDecisions<FakeState> = {
-      apiKey: {
-        allowed: false,
-        retryAfter: 200,
-        remaining: 0,
-        nextState: { key: "api-key-state" },
-      },
-      ip: {
-        allowed: false,
-        retryAfter: 500,
-        remaining: 0,
-        nextState: { key: "ip-state" },
-      },
-      tenant: {
-        allowed: true,
-        retryAfter: 0,
-        remaining: 19,
-        nextState: { key: "tenant-state" },
-      },
-    };
+    const decisions = {
+      apiKey: { allowed: false, retryAfter: 200 },
+      ip: { allowed: false, retryAfter: 500 },
+      tenant: { allowed: true, retryAfter: 0 },
+    } as unknown as LimitDecisions<never>;
     const evaluator = new DecisionEvaluator();
 
     const actualDecision = evaluator.evaluate(decisions);
@@ -101,14 +52,9 @@ describe("decision evaluator", () => {
   });
 
   test("should ignore dimensions that were not evaluated", () => {
-    const decisions: LimitDecisions<FakeState> = {
-      apiKey: {
-        allowed: true,
-        retryAfter: 0,
-        remaining: 9,
-        nextState: { key: "api-key-state" },
-      },
-    };
+    const decisions = {
+      apiKey: { allowed: true, retryAfter: 0 },
+    } as unknown as LimitDecisions<never>;
     const evaluator = new DecisionEvaluator();
 
     const actualDecision = evaluator.evaluate(decisions);

--- a/src/Domain/Service/DecisionEvaluator.test.ts
+++ b/src/Domain/Service/DecisionEvaluator.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { LimitDecisions } from "../types.ts";
+import { DecisionEvaluator } from "./DecisionEvaluator.ts";
+
+type FakeState = {
+  key: string;
+};
+
+describe("decision evaluator", () => {
+  test("should return an allowed enforcement decision when all evaluated dimensions are allowed", () => {
+    const decisions: LimitDecisions<FakeState> = {
+      apiKey: {
+        allowed: true,
+        retryAfter: 0,
+        remaining: 9,
+        nextState: { key: "api-key-state" },
+      },
+      ip: {
+        allowed: true,
+        retryAfter: 0,
+        remaining: 4,
+        nextState: { key: "ip-state" },
+      },
+      tenant: {
+        allowed: true,
+        retryAfter: 0,
+        remaining: 19,
+        nextState: { key: "tenant-state" },
+      },
+    };
+    const evaluator = new DecisionEvaluator();
+
+    const actualDecision = evaluator.evaluate(decisions);
+
+    expect(actualDecision).toEqual({
+      allowed: true,
+      retryAfter: 0,
+    });
+  });
+});

--- a/src/Domain/Service/DecisionEvaluator.ts
+++ b/src/Domain/Service/DecisionEvaluator.ts
@@ -1,22 +1,22 @@
-import { Decision, EnforcementDecision, LimitDecisions } from "../types.ts";
+import { EnforcementDecision, LimitDecisions } from "../types.ts";
 
 export class DecisionEvaluator {
   evaluate<State>(decisions: LimitDecisions<State>): EnforcementDecision {
-    const evaluatedDecisions: Decision<State>[] = [
+    const allDecisions = [
       decisions.apiKey,
       decisions.ip,
       decisions.tenant,
     ].filter((decision) => decision !== undefined);
-    const rejectedDecisions = evaluatedDecisions.filter(
-      (decision) => !decision.allowed,
+
+    const allowed = allDecisions.every((decision) => decision.allowed);
+    const retryAfter = Math.max(
+      0,
+      ...allDecisions.map((decision) => decision.retryAfter),
     );
 
     return {
-      allowed: rejectedDecisions.length === 0,
-      retryAfter: Math.max(
-        0,
-        ...rejectedDecisions.map((decision) => decision.retryAfter),
-      ),
+      allowed,
+      retryAfter,
     };
   }
 }

--- a/src/Domain/Service/DecisionEvaluator.ts
+++ b/src/Domain/Service/DecisionEvaluator.ts
@@ -1,0 +1,10 @@
+import { EnforcementDecision, LimitDecisions } from "../types.ts";
+
+export class DecisionEvaluator {
+  evaluate<State>(decisions: LimitDecisions<State>): EnforcementDecision {
+    return {
+      allowed: decisions.apiKey.allowed,
+      retryAfter: decisions.apiKey.retryAfter,
+    };
+  }
+}

--- a/src/Domain/Service/DecisionEvaluator.ts
+++ b/src/Domain/Service/DecisionEvaluator.ts
@@ -1,10 +1,22 @@
-import { EnforcementDecision, LimitDecisions } from "../types.ts";
+import { Decision, EnforcementDecision, LimitDecisions } from "../types.ts";
 
 export class DecisionEvaluator {
   evaluate<State>(decisions: LimitDecisions<State>): EnforcementDecision {
+    const evaluatedDecisions: Decision<State>[] = [
+      decisions.apiKey,
+      decisions.ip,
+      decisions.tenant,
+    ].filter((decision) => decision !== undefined);
+    const rejectedDecisions = evaluatedDecisions.filter(
+      (decision) => !decision.allowed,
+    );
+
     return {
-      allowed: decisions.apiKey.allowed,
-      retryAfter: decisions.apiKey.retryAfter,
+      allowed: rejectedDecisions.length === 0,
+      retryAfter: Math.max(
+        0,
+        ...rejectedDecisions.map((decision) => decision.retryAfter),
+      ),
     };
   }
 }

--- a/src/Domain/Service/RateLimiterService.test.ts
+++ b/src/Domain/Service/RateLimiterService.test.ts
@@ -6,7 +6,7 @@ import {
   LimitDecisions,
   StateIdentifiers,
 } from "../types.ts";
-import { LimitService } from "./LimitService.ts";
+import { rateLimiterService } from "./RateLimiterService.ts";
 import { RateLimiterInterface } from "../Algorithm/RateLimiterInterface.ts";
 
 type FakeState = {
@@ -30,8 +30,8 @@ describe("limit service", () => {
     const MockedAlgorithm: RateLimiterInterface<FakeState, FakeConfig> = {
       attempt: vi.fn().mockReturnValue(expectedDecision),
     };
-    const limitService = new LimitService(mockedRepository, MockedAlgorithm);
-    const stateIdentifiers: StateIdentifiers = { apikey: "apikey-identifier" };
+    const limitService = new rateLimiterService(mockedRepository, MockedAlgorithm);
+    const stateIdentifiers: StateIdentifiers = { apiKey: "apikey-identifier" };
     const algorithmConfig: LimitPolicies<FakeConfig> = {
       apiKey: { key: "example-config-key" },
     };
@@ -41,10 +41,10 @@ describe("limit service", () => {
 
     expect(actualDecisions).toEqual({ apiKey: expectedDecision });
     expect(mockedRepository.findOneBy).toHaveBeenCalledWith(
-      stateIdentifiers.apikey,
+      stateIdentifiers.apiKey,
     );
     expect(mockedRepository.save).toHaveBeenCalledWith(
-      stateIdentifiers.apikey,
+      stateIdentifiers.apiKey,
       expectedDecision.nextState,
     );
   });
@@ -76,9 +76,9 @@ describe("limit service", () => {
         .mockReturnValueOnce(expectedDecisions.ip)
         .mockReturnValueOnce(expectedDecisions.tenant),
     };
-    const limitService = new LimitService(mockedRepository, MockedAlgorithm);
+    const limitService = new rateLimiterService(mockedRepository, MockedAlgorithm);
     const stateIdentifiers: StateIdentifiers = {
-      apikey: "apikey-identifier",
+      apiKey: "apikey-identifier",
       ip: "ip-identifier",
       tenant: "tenant-identifier",
     };
@@ -96,7 +96,7 @@ describe("limit service", () => {
 
     expect(actualDecisions).toEqual(expectedDecisions);
     expect(mockedRepository.findOneBy).toHaveBeenCalledWith(
-      stateIdentifiers.apikey,
+      stateIdentifiers.apiKey,
     );
     expect(mockedRepository.findOneBy).toHaveBeenCalledWith(
       stateIdentifiers.ip,
@@ -105,7 +105,7 @@ describe("limit service", () => {
       stateIdentifiers.tenant,
     );
     expect(mockedRepository.save).toHaveBeenCalledWith(
-      stateIdentifiers.apikey,
+      stateIdentifiers.apiKey,
       expectedDecisions.apiKey.nextState,
     );
     expect(mockedRepository.save).toHaveBeenCalledWith(

--- a/src/Domain/Service/RateLimiterService.test.ts
+++ b/src/Domain/Service/RateLimiterService.test.ts
@@ -30,7 +30,10 @@ describe("limit service", () => {
     const MockedAlgorithm: RateLimiterInterface<FakeState, FakeConfig> = {
       attempt: vi.fn().mockReturnValue(expectedDecision),
     };
-    const limitService = new rateLimiterService(mockedRepository, MockedAlgorithm);
+    const limitService = new rateLimiterService(
+      mockedRepository,
+      MockedAlgorithm,
+    );
     const stateIdentifiers: StateIdentifiers = { apiKey: "apikey-identifier" };
     const algorithmConfig: Policies<FakeConfig> = {
       apiKey: { key: "example-config-key" },
@@ -76,7 +79,10 @@ describe("limit service", () => {
         .mockReturnValueOnce(expectedDecisions.ip)
         .mockReturnValueOnce(expectedDecisions.tenant),
     };
-    const limitService = new rateLimiterService(mockedRepository, MockedAlgorithm);
+    const limitService = new rateLimiterService(
+      mockedRepository,
+      MockedAlgorithm,
+    );
     const stateIdentifiers: StateIdentifiers = {
       apiKey: "apikey-identifier",
       ip: "ip-identifier",

--- a/src/Domain/Service/RateLimiterService.test.ts
+++ b/src/Domain/Service/RateLimiterService.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 import { StateRepositoryInterface } from "../Repository/StateRepositoryInterface.ts";
 import {
   Decision,
-  LimitPolicies,
+  Policies,
   LimitDecisions,
   StateIdentifiers,
 } from "../types.ts";
@@ -32,7 +32,7 @@ describe("limit service", () => {
     };
     const limitService = new rateLimiterService(mockedRepository, MockedAlgorithm);
     const stateIdentifiers: StateIdentifiers = { apiKey: "apikey-identifier" };
-    const algorithmConfig: LimitPolicies<FakeConfig> = {
+    const algorithmConfig: Policies<FakeConfig> = {
       apiKey: { key: "example-config-key" },
     };
 
@@ -82,7 +82,7 @@ describe("limit service", () => {
       ip: "ip-identifier",
       tenant: "tenant-identifier",
     };
-    const algorithmConfig: LimitPolicies<FakeConfig> = {
+    const algorithmConfig: Policies<FakeConfig> = {
       apiKey: { key: "api-config" },
       ip: { key: "ip-config" },
       tenant: { key: "tenant-config" },

--- a/src/Domain/Service/RateLimiterService.ts
+++ b/src/Domain/Service/RateLimiterService.ts
@@ -7,7 +7,7 @@ import {
   StateIdentifiers,
 } from "../types.ts";
 
-export class LimitService<State, Policy> {
+export class rateLimiterService<State, Policy> {
   constructor(
     private readonly stateRepository: StateRepositoryInterface<State>,
     private readonly limitingAlgorithm: RateLimiterInterface<State, Policy>,
@@ -20,7 +20,7 @@ export class LimitService<State, Policy> {
   ): Promise<LimitDecisions<State>> {
     const limitDecisions: LimitDecisions<State> = {
       apiKey: await this.attempt(
-        identifiers.apikey,
+        identifiers.apiKey,
         policies.apiKey,
         requestedAt,
       ),

--- a/src/Domain/Service/RateLimiterService.ts
+++ b/src/Domain/Service/RateLimiterService.ts
@@ -2,7 +2,7 @@ import { RateLimiterInterface } from "../Algorithm/RateLimiterInterface.ts";
 import { StateRepositoryInterface } from "../Repository/StateRepositoryInterface.ts";
 import {
   Decision,
-  LimitPolicies,
+  Policies,
   LimitDecisions,
   StateIdentifiers,
 } from "../types.ts";
@@ -15,7 +15,7 @@ export class rateLimiterService<State, Policy> {
 
   async execute(
     identifiers: StateIdentifiers,
-    policies: LimitPolicies<Policy>,
+    policies: Policies<Policy>,
     requestedAt: number,
   ): Promise<LimitDecisions<State>> {
     const limitDecisions: LimitDecisions<State> = {

--- a/src/Domain/types.ts
+++ b/src/Domain/types.ts
@@ -23,7 +23,7 @@ export type LimitPolicies<Policy> = {
 };
 
 export type StateIdentifiers = {
-  apikey: string;
+  apiKey: string;
   ip?: string;
   tenant?: string;
 };

--- a/src/Domain/types.ts
+++ b/src/Domain/types.ts
@@ -16,7 +16,7 @@ export type LimitDecisions<State> = {
   tenant?: Decision<State>;
 };
 
-export type LimitPolicies<Policy> = {
+export type Policies<Policy> = {
   apiKey: Policy;
   ip?: Policy;
   tenant?: Policy;

--- a/src/Domain/types.ts
+++ b/src/Domain/types.ts
@@ -5,6 +5,11 @@ export type Decision<State> = {
   nextState: State;
 };
 
+export type EnforcementDecision = {
+  allowed: boolean;
+  retryAfter: number;
+};
+
 export type LimitDecisions<State> = {
   apiKey: Decision<State>;
   ip?: Decision<State>;


### PR DESCRIPTION
## Summary

- This PR introduced the `DecisionEvaluator` which evaluate the  three dimension decisions returned from the `rateLimiterService` and return one `EnforcementDecision`.
---

## Changes
<!-- write changes you have done in points --> 
- Added DecisionEvaluator and it's testCase
- Change the return of EnforceRateLimitUseCase
- rename `UserIdentity` to `Identities`
- rename `LimitPolicy` to `Polices` 
- fix key name from `apikey` to `apiKey`
- rename `limitService` to `rateLimiterService`

---

## Architecture Notes
<!-- this section for any architecture decisions you have made -->
- `DecisionEvaluator` put under `Domain` layer, as it's business logic
---

Closes #52 

Related to #<pr_number><issue_number>