### PR TITLE
Centralize Redis client configuration

### DIFF
--- a/src/Infrastructure/Cache/Redis/Client/getClient.test.ts
+++ b/src/Infrastructure/Cache/Redis/Client/getClient.test.ts
@@ -4,6 +4,7 @@ import { createClient } from "./createClient.ts";
 
 type RedisClient = Awaited<ReturnType<typeof createClient>>;
 let getClient: typeof import("./getClient.ts").getClient;
+let configureRedis: typeof import("./getClient.ts").configureRedis;
 
 vi.mock("./createClient.ts", () => ({
   createClient: vi.fn(),
@@ -13,19 +14,40 @@ describe("Redis client singleton", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.resetModules();
-    ({ getClient } = await import("./getClient.ts"));
+    ({ getClient, configureRedis } = await import("./getClient.ts"));
   });
 
   test("should create Redis client only once", async () => {
     const config: Config = { url: "redis://localhost:6379" };
     const client = { id: "redis-client" } as unknown as RedisClient;
     vi.mocked(createClient).mockResolvedValue(client);
+    configureRedis(config);
 
-    const firstClient = await getClient(config);
-    const secondClient = await getClient(config);
+    const firstClient = await getClient();
+    const secondClient = await getClient();
 
     expect(firstClient).toBe(client);
     expect(secondClient).toBe(client);
+    expect(createClient).toHaveBeenCalledOnce();
+    expect(createClient).toHaveBeenCalledWith(config);
+  });
+
+  test("should configure Redis without creating a client", () => {
+    const config: Config = { url: "redis://localhost:6379" };
+
+    configureRedis(config);
+
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  test("should create Redis client with configured Redis settings", async () => {
+    const config: Config = { url: "redis://localhost:6380" };
+    const client = { id: "redis-client" } as unknown as RedisClient;
+    vi.mocked(createClient).mockResolvedValue(client);
+
+    configureRedis(config);
+
+    await expect(getClient()).resolves.toBe(client);
     expect(createClient).toHaveBeenCalledOnce();
     expect(createClient).toHaveBeenCalledWith(config);
   });
@@ -34,10 +56,11 @@ describe("Redis client singleton", () => {
     const config: Config = { url: "redis://localhost:6379" };
     const client = { id: "redis-client" } as unknown as RedisClient;
     vi.mocked(createClient).mockResolvedValue(client);
+    configureRedis(config);
 
     const [firstClient, secondClient] = await Promise.all([
-      getClient(config),
-      getClient(config),
+      getClient(),
+      getClient(),
     ]);
 
     expect(firstClient).toBe(client);
@@ -50,9 +73,11 @@ describe("Redis client singleton", () => {
     const secondConfig: Config = { url: "redis://localhost:6380" };
     const client = { id: "redis-client" } as unknown as RedisClient;
     vi.mocked(createClient).mockResolvedValue(client);
+    configureRedis(firstConfig);
+    await getClient();
+    configureRedis(secondConfig);
 
-    await getClient(firstConfig);
-    const secondClient = await getClient(secondConfig);
+    const secondClient = await getClient();
 
     expect(secondClient).toBe(client);
     expect(createClient).toHaveBeenCalledOnce();
@@ -65,9 +90,10 @@ describe("Redis client singleton", () => {
     vi.mocked(createClient)
       .mockRejectedValueOnce(new Error("connection failed"))
       .mockResolvedValueOnce(client);
+    configureRedis(config);
 
-    await expect(getClient(config)).rejects.toThrow("connection failed");
-    await expect(getClient(config)).resolves.toBe(client);
+    await expect(getClient()).rejects.toThrow("connection failed");
+    await expect(getClient()).resolves.toBe(client);
 
     expect(createClient).toHaveBeenCalledTimes(2);
     expect(createClient).toHaveBeenCalledWith(config);

--- a/src/Infrastructure/Cache/Redis/Client/getClient.ts
+++ b/src/Infrastructure/Cache/Redis/Client/getClient.ts
@@ -4,8 +4,13 @@ import { createClient } from "./createClient.ts";
 export type RedisClient = Awaited<ReturnType<typeof createClient>>;
 
 let clientPromise: Promise<RedisClient> | undefined;
+let redisConfig: Config = config;
 
-export function getClient(redisConfig: Config = config): Promise<RedisClient> {
+export function configureRedis(redisSettings: Config): void {
+  redisConfig = redisSettings;
+}
+
+export function getClient(): Promise<RedisClient> {
   clientPromise ??= createClient(redisConfig).catch((error: unknown) => {
     clientPromise = undefined;
     throw error;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import type { TokenBucketPolicy } from "./Domain/Algorithm/types.ts";
 import { DecisionEvaluator } from "./Domain/Service/DecisionEvaluator.ts";
 import { RateLimiterService } from "./Domain/Service/RateLimiterService.ts";
 import type { EnforcementDecision, Policies } from "./Domain/types.ts";
-import { createClient } from "./Infrastructure/Cache/Redis/Client/createClient.ts";
+import { configureRedis } from "./Infrastructure/Cache/Redis/Client/getClient.ts";
 import { RedisIdentifierBuilder } from "./Infrastructure/Cache/Redis/Identifier/RedisIdentifierBuilder.ts";
 import { tokenBucketStateRepository } from "./Infrastructure/Cache/Redis/Repository/TokenBucketStateRepository.ts";
 
@@ -25,7 +25,7 @@ export type TrafficOfficer = {
 export function createTrafficOfficer(
   config: TrafficOfficerConfig,
 ): TrafficOfficer {
-  createClient({ url: config.dbUrl });
+  configureRedis({ url: config.dbUrl });
 
   const rateLimiterService = new RateLimiterService(
     new tokenBucketStateRepository(),


### PR DESCRIPTION
## Summary

This PR centralizes the Redis client lifecycle inside the Redis infrastructure boundary.

Previously, the composition layer imported and called `createClient()` directly when creating the public `TrafficOfficer` API. Because `createClient()` is asynchronous, that made Redis connection setup visible from composition and allowed the service to continue being assembled while the Redis connection was still in progress.

The composition layer does not actually need an active Redis client during construction. It only needs to provide Redis settings. The repository is the component that needs Redis later, when `findOneBy` or `save` is called.

## What changed

- Added `configureRedis(redisSettings)` to the Redis client module.
- Kept Redis connection creation lazy inside `getClient()`.
- Changed `getClient()` so it no longer accepts per-call configuration.
- Updated composition to call `configureRedis({ url: config.dbUrl })` instead of calling `createClient()` directly.
- Preserved the existing singleton behavior:
  - one Redis client promise is reused
  - concurrent calls share the same pending connection
  - failed connection attempts clear the cached promise so a later call can retry
  - once a client is initialized, later configuration changes do not replace it implicitly

## Why

This keeps asynchronous Redis initialization hidden inside infrastructure and avoids spreading connection lifecycle responsibility into the composition layer.

The composition layer now performs only synchronous configuration. The actual async connection is centralized and awaited by `getClient()` when Redis is genuinely needed by repository methods.

This reduces the risk of:

- race conditions from starting Redis connection work outside the module that owns it
- duplicated Redis initialization paths
- repository methods observing an incompletely initialized client
- leaking infrastructure lifecycle details into higher-level wiring code


Closes #59 
