### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ jobs:
   ci:
     runs-on: ubuntu-latest
 
+    services:
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run cc

--- a/tests/trafficOfficer.integration.test.ts
+++ b/tests/trafficOfficer.integration.test.ts
@@ -135,7 +135,7 @@ describe("traffic officer", () => {
       const officer = createOfficer();
 
       await expect(officer.enforce(identities, policies, requestedAt)).rejects.toThrow(
-        "apiKey is required to enforce rate limits",
+        "apiKey identity is required to enforce rate limits",
       );
     });
   });


### PR DESCRIPTION
## Summary
- Add a simple GitHub Actions CI workflow for the project
- Set up Node.js 24 and install dependencies with `npm ci`
- Start Redis on port `6379` for the integration tests
- Run the existing `npm run cc` command as the CI check
- Align the api key identity integration test expectation with the current application error message

## Verification
- `npx vitest run src/Application/EnforceRateLimitUseCase.test.ts`
- Full local `npm test` requires Redis; CI provides Redis through the workflow service container

Closes #27