### PR TITLE
feat: track rate limit state validity and delete expired state

### DIFF
--- a/src/Domain/Algorithm/TokenBucket.test.ts
+++ b/src/Domain/Algorithm/TokenBucket.test.ts
@@ -102,6 +102,44 @@ describe("Token bucket algorithm", () => {
     });
   });
 
+  describe("state expiration", () => {
+    test("returns the time until the bucket is refilled with the limit again when allowed", () => {
+      const tokenBucket = new TokenBucket();
+      const currentState = { tokensCount: 3, lastUpdatedAtInMs: 1_000 };
+      const policy = { bucketCapacityLimit: 5, refillRate: { amount: 2, perMs: 1_000 } };
+
+      const actualDecision = tokenBucket.attempt(currentState, policy, 1_000);
+
+      expect(actualDecision.allowed).toBeTruthy();
+      expect(actualDecision.nextState.tokensCount).toEqual(2);
+      expect(actualDecision.stateValidForMs).toEqual(1_500);
+    });
+
+    test("returns the time until the bucket is refilled with the limit again when rejected", () => {
+      const tokenBucket = new TokenBucket();
+      const currentState = { tokensCount: 0.4, lastUpdatedAtInMs: 1_000 };
+      const policy = { bucketCapacityLimit: 5, refillRate: { amount: 2, perMs: 1_000 } };
+
+      const actualDecision = tokenBucket.attempt(currentState, policy, 1_000);
+
+      expect(actualDecision.allowed).toBeFalsy();
+      expect(actualDecision.nextState.tokensCount).toEqual(0.4);
+      expect(actualDecision.stateValidForMs).toEqual(2_300);
+    });
+
+    test("returns the time after refilling to the limit before consumption", () => {
+      const tokenBucket = new TokenBucket();
+      const currentState = { tokensCount: 5, lastUpdatedAtInMs: 1_000 };
+      const policy = { bucketCapacityLimit: 5, refillRate: { amount: 2, perMs: 1_000 } };
+
+      const actualDecision = tokenBucket.attempt(currentState, policy, 3_000);
+
+      expect(actualDecision.allowed).toBeTruthy();
+      expect(actualDecision.nextState.tokensCount).toEqual(4);
+      expect(actualDecision.stateValidForMs).toEqual(500);
+    });
+  });
+
   describe("remaining tokens", () => {
     test("decreases by consumption cost if allowed", () => {
       const tokenBucket = new TokenBucket();

--- a/src/Domain/Algorithm/TokenBucket.ts
+++ b/src/Domain/Algorithm/TokenBucket.ts
@@ -29,7 +29,7 @@ export class TokenBucket implements AlgorithmInterface<TokenBucketState, TokenBu
     const remainingTokens: number = Math.round((refilledTokens - CONSUMPTION_AMOUNT) * 1000) / 1000;
 
     return remainingTokens >= 0
-      ? this.allowed(remainingTokens, updatedAt)
+      ? this.allowed(remainingTokens, updatedAt, policy)
       : this.rejected(remainingTokens, updatedAt, policy, refilledTokens);
   }
 
@@ -40,7 +40,7 @@ export class TokenBucket implements AlgorithmInterface<TokenBucketState, TokenBu
     return Math.min(policy.bucketCapacityLimit, currentBucketState.tokensCount + tokensCountCanBeRefiled);
   }
 
-  allowed(remainingTokens: number, updatedAt: number): Decision<TokenBucketState> {
+  allowed(remainingTokens: number, updatedAt: number, policy: TokenBucketPolicy): Decision<TokenBucketState> {
     return {
       allowed: true,
       retryAfter: 0,
@@ -49,7 +49,7 @@ export class TokenBucket implements AlgorithmInterface<TokenBucketState, TokenBu
         tokensCount: remainingTokens,
         lastUpdatedAtInMs: updatedAt,
       },
-      stateExpiresInMs: 0,
+      stateValidForMs: this.stateValidFor(remainingTokens, policy),
     };
   }
 
@@ -67,7 +67,13 @@ export class TokenBucket implements AlgorithmInterface<TokenBucketState, TokenBu
         tokensCount: Math.trunc(refilledTokens * 100) / 100,
         lastUpdatedAtInMs: updatedAt,
       },
-      stateExpiresInMs: 0,
+      stateValidForMs: this.stateValidFor(Math.trunc(refilledTokens * 100) / 100, policy),
     };
+  }
+
+  stateValidFor(tokensCount: number, policy: TokenBucketPolicy): number {
+    const tokensCountToRefill = Math.max(0, policy.bucketCapacityLimit - tokensCount);
+
+    return Math.ceil((tokensCountToRefill * policy.refillRate.perMs) / policy.refillRate.amount);
   }
 }

--- a/src/Domain/Decision.ts
+++ b/src/Domain/Decision.ts
@@ -3,5 +3,5 @@ export type Decision<State> = {
   retryAfter: number;
   remaining: number;
   nextState: State;
-  stateExpiresInMs: number;
+  stateValidForMs: number;
 };

--- a/src/Domain/Repository/StateRepositoryInterface.ts
+++ b/src/Domain/Repository/StateRepositoryInterface.ts
@@ -1,4 +1,5 @@
 export interface StateRepositoryInterface<State> {
   findOneBy(key: string): Promise<State | null>;
   save(key: string, state: State, ttl?: number): Promise<void>;
+  delete(key: string): Promise<void>;
 }

--- a/src/Domain/Service/TrafficLimiter.test.ts
+++ b/src/Domain/Service/TrafficLimiter.test.ts
@@ -23,7 +23,7 @@ describe("rate limit service", () => {
   test("returns a decision for the required apiKey identity", async () => {
     const currentStates = [{ key: "current-apiKey-state" }];
     const mockedRepository = mockRepository(currentStates);
-    const mockedExpectedDecisions = { apiKey: { nextState: { key: "new-apiKey-state" } } };
+    const mockedExpectedDecisions = { apiKey: { nextState: { key: "new-apiKey-state" }, stateValidForMs: 1_000 } };
     const mockedAlgorithm = mockAlgorithm(mockedExpectedDecisions);
     const limitService = new TrafficLimiter(mockedRepository, mockedAlgorithm);
     const identifier = { apiKey: identifiers["apiKey"] };
@@ -37,7 +37,9 @@ describe("rate limit service", () => {
     expect(mockedRepository.save).toHaveBeenCalledExactlyOnceWith(
       identifier.apiKey,
       mockedExpectedDecisions.apiKey.nextState,
+      mockedExpectedDecisions.apiKey.stateValidForMs,
     );
+    expect(mockedRepository.delete).not.toHaveBeenCalled();
   });
 
   test("limit returns decisions for all optional dimensions", async () => {
@@ -48,9 +50,9 @@ describe("rate limit service", () => {
     ];
     const mockedRepository = mockRepository(currentStates);
     const mockedExpectedDecisions = {
-      apiKey: { nextState: { state: "new-apiKey-state" } },
-      ip: { nextState: { state: "new-ip-state" } },
-      tenant: { nextState: { state: "new-tenant-state" } },
+      apiKey: { nextState: { state: "new-apiKey-state" }, stateValidForMs: 1_000 },
+      ip: { nextState: { state: "new-ip-state" }, stateValidForMs: 2_000 },
+      tenant: { nextState: { state: "new-tenant-state" }, stateValidForMs: 3_000 },
     };
     const mockedAlgorithm = mockAlgorithm(mockedExpectedDecisions);
     const limitService = new TrafficLimiter(mockedRepository, mockedAlgorithm);
@@ -63,13 +65,26 @@ describe("rate limit service", () => {
     expect(mockedAlgorithm.attempt).toHaveBeenCalledTimes(3);
     expect(mockedRepository.findOneBy).toHaveBeenCalledWith(identifiers.apiKey);
     expect(mockedAlgorithm.attempt).toHaveBeenCalledWith(currentStates[0], policies.apiKey, 1_000);
-    expect(mockedRepository.save).toHaveBeenCalledWith(identifiers.apiKey, mockedExpectedDecisions.apiKey.nextState);
+    expect(mockedRepository.save).toHaveBeenCalledWith(
+      identifiers.apiKey,
+      mockedExpectedDecisions.apiKey.nextState,
+      mockedExpectedDecisions.apiKey.stateValidForMs,
+    );
     expect(mockedRepository.findOneBy).toHaveBeenCalledWith(identifiers.ip);
     expect(mockedAlgorithm.attempt).toHaveBeenCalledWith(currentStates[1], policies.ip, 1_000);
-    expect(mockedRepository.save).toHaveBeenCalledWith(identifiers.ip, mockedExpectedDecisions.ip?.nextState);
+    expect(mockedRepository.save).toHaveBeenCalledWith(
+      identifiers.ip,
+      mockedExpectedDecisions.ip?.nextState,
+      mockedExpectedDecisions.ip?.stateValidForMs,
+    );
     expect(mockedRepository.findOneBy).toHaveBeenCalledWith(identifiers.tenant);
     expect(mockedAlgorithm.attempt).toHaveBeenCalledWith(currentStates[2], policies.tenant, 1_000);
-    expect(mockedRepository.save).toHaveBeenCalledWith(identifiers.tenant, mockedExpectedDecisions.tenant?.nextState);
+    expect(mockedRepository.save).toHaveBeenCalledWith(
+      identifiers.tenant,
+      mockedExpectedDecisions.tenant?.nextState,
+      mockedExpectedDecisions.tenant?.stateValidForMs,
+    );
+    expect(mockedRepository.delete).not.toHaveBeenCalled();
   });
 
   test.each([
@@ -86,7 +101,7 @@ describe("rate limit service", () => {
   ])(`ignores optional dimensions when either their $missing missing`, async ({ identifiers, policies }) => {
     const currentStates = [{ key: "current-apiKey-state" }];
     const mockedRepository = mockRepository(currentStates);
-    const expectedDecision = { apiKey: { nextState: { key: "new-apiKey-state" } } };
+    const expectedDecision = { apiKey: { nextState: { key: "new-apiKey-state" }, stateValidForMs: 1_000 } };
     const mockedAlgorithm = mockAlgorithm(expectedDecision);
     const limitService = new TrafficLimiter(mockedRepository, mockedAlgorithm);
 
@@ -98,7 +113,27 @@ describe("rate limit service", () => {
     expect(mockedRepository.save).toHaveBeenCalledExactlyOnceWith(
       identifiers.apiKey,
       expectedDecision.apiKey.nextState,
+      expectedDecision.apiKey.stateValidForMs,
     );
+    expect(mockedRepository.delete).not.toHaveBeenCalled();
+  });
+
+  test("deletes state when the decision does not need to be kept", async () => {
+    const currentStates = [{ key: "current-apiKey-state" }];
+    const mockedRepository = mockRepository(currentStates);
+    const expectedDecision = { apiKey: { nextState: { key: "new-apiKey-state" }, stateValidForMs: 0 } };
+    const mockedAlgorithm = mockAlgorithm(expectedDecision);
+    const limitService = new TrafficLimiter(mockedRepository, mockedAlgorithm);
+    const identifier = { apiKey: identifiers["apiKey"] };
+    const policy = { apiKey: policies["apiKey"] };
+
+    const actualDecisions = await limitService.execute(identifier, policy, 1_000);
+
+    expect(actualDecisions).toEqual(expectedDecision);
+    expect(mockedRepository.findOneBy).toHaveBeenCalledExactlyOnceWith(identifier.apiKey);
+    expect(mockedAlgorithm.attempt).toHaveBeenCalledExactlyOnceWith(currentStates[0], policy.apiKey, 1_000);
+    expect(mockedRepository.save).not.toHaveBeenCalled();
+    expect(mockedRepository.delete).toHaveBeenCalledExactlyOnceWith(identifier.apiKey);
   });
 
   function mockAlgorithm<State, Policy>(decisions: object): AlgorithmInterface<State, Policy> {
@@ -121,6 +156,7 @@ describe("rate limit service", () => {
     return {
       findOneBy,
       save: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
     };
   }
 });

--- a/src/Domain/Service/TrafficLimiter.ts
+++ b/src/Domain/Service/TrafficLimiter.ts
@@ -45,7 +45,9 @@ export class TrafficLimiter<State, Policy> {
       requestedAt,
     );
 
-    await this.stateRepository.save(identifiers[dimension] as string, decision.nextState);
+    if (decision.stateValidForMs > 0)
+      await this.stateRepository.save(identifiers[dimension] as string, decision.nextState, decision.stateValidForMs);
+    else await this.stateRepository.delete(identifiers[dimension] as string);
 
     return decision;
   }

--- a/src/Infrastructure/Cache/Redis/Repository/stateRepository.test.ts
+++ b/src/Infrastructure/Cache/Redis/Repository/stateRepository.test.ts
@@ -69,4 +69,17 @@ describe("Redis bucket repository", () => {
 
     expect(redisClient.set).toHaveBeenCalledWith(key, JSON.stringify(bucketState), undefined);
   });
+
+  test("deletes bucket state", async () => {
+    const key = "bucket:user:123";
+    const redisClient = {
+      del: vi.fn(),
+    } as unknown as RedisClientType;
+    vi.mocked(getClient).mockResolvedValue(redisClient);
+    const repository = new stateRepository<mockState>();
+
+    await repository.delete(key);
+
+    expect(redisClient.del).toHaveBeenCalledWith(key);
+  });
 });

--- a/src/Infrastructure/Cache/Redis/Repository/stateRepository.ts
+++ b/src/Infrastructure/Cache/Redis/Repository/stateRepository.ts
@@ -21,4 +21,10 @@ export class stateRepository<State> implements StateRepositoryInterface<State> {
 
     await client?.set(key, JSON.stringify(state), options);
   }
+
+  async delete(key: string): Promise<void> {
+    const client = await getClient();
+
+    await client?.del(key);
+  }
 }


### PR DESCRIPTION
## Summary

This PR teaches the token bucket algorithm to report how long its returned state remains useful, then uses that value in the traffic limiter to decide whether the state should be persisted or deleted.

## Why

For a token bucket, once the bucket has naturally refilled back to the configured capacity limit, persisted state no longer changes the next decision. If no state exists for that key, the algorithm already treats the bucket as full. Keeping cache state past that point is unnecessary and can make the cache hold values that no longer carry domain meaning.

## Changes

### Token bucket state validity

- Replaces `stateExpiresInMs` with the domain-oriented name `stateValidForMs`.
- Calculates `stateValidForMs` from the number of tokens missing from the bucket after the decision.
- Uses the refill rate to determine how many milliseconds are needed for the bucket to become full again.
- Keeps this calculation in the domain algorithm without introducing Redis/cache-specific language.

### Traffic limiter persistence behavior

- Saves `decision.nextState` only when `decision.stateValidForMs > 0`.
- Passes `stateValidForMs` as the repository TTL when saving state.
- Deletes the state when `stateValidForMs` is `0`, because the state does not need to be kept.

### Repository contract and Redis adapter

- Adds `delete(key)` to `StateRepositoryInterface`.
- Implements Redis deletion with `DEL` in the infrastructure repository.
- Keeps Redis details behind the repository interface.

## Tests

Added/updated tests for:

- Token bucket validity duration when requests are allowed.
- Token bucket validity duration when requests are rejected.
- Traffic limiter saving state with a validity duration.
- Traffic limiter deleting state when the decision state does not need to be kept.
- Redis repository deleting stored state.

closes #26 